### PR TITLE
GCNAugmentedDataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/.DS_Store
+.idea
+.ipynb_checkpoints

--- a/GCN/multiclass_classification_GCN_acc_minmaxscaler_for_feature.py
+++ b/GCN/multiclass_classification_GCN_acc_minmaxscaler_for_feature.py
@@ -6,6 +6,7 @@ import time
 import copy
 import os
 import itertools
+import random
 
 import numpy as np
 import pandas as pd
@@ -87,8 +88,56 @@ class GCNDataset(Dataset):
     
     def __getitem__(self, index):
         return self.list_feature[index], self.list_adj[index], self.list_NIH_score[index]
-    
-    
+
+
+class GCNAugmentedDataset(Dataset):
+    def __init__(
+        self,
+        list_feature,
+        list_adj,
+        list_NIH_score,
+        feat_mask_apply_prob: float = 0.5,  # 매 instance 마다 feature masking augmentation 적용할 확률
+        feat_mask_prob: float = 0.1,  # feature masking 적용할 때 masking 할 노드의 percentage
+        edge_perturb_apply_prob: float = 0.5,  # 매 instance 마다 edge perturbation augmentation 적용할 확률
+        edge_perturb_prob: float = 0.1,  # edge perturbation 적용할 때 perturb 할 edge 의 percentage
+        seed: int = 0,  # random seed for reproducibility
+    ):
+        self.list_feature = list_feature.astype(np.float32)
+        self.list_adj = list_adj.astype(np.float32)
+        self.list_NIH_score = list_NIH_score
+        assert all(0.0 <= p <= 1.0 for p in [feat_mask_apply_prob, feat_mask_prob, edge_perturb_apply_prob, edge_perturb_prob])
+        self.feat_mask_apply_prob = feat_mask_apply_prob
+        self.feat_mask_prob = feat_mask_prob
+        self.edge_perturb_apply_prob = edge_perturb_apply_prob
+        self.edge_perturb_prob = edge_perturb_prob
+        self.rng = np.random.default_rng(seed)
+
+    def __len__(self):
+        return len(self.list_feature)
+
+    def __getitem__(self, index):
+        orig_feat, orig_adj, orig_score = self.list_feature[index], self.list_adj[index], self.list_NIH_score[index]
+        aug_feat = np.copy(orig_feat)
+        aug_adj = np.copy(orig_adj)
+        num_nodes = orig_feat.shape[0]
+        if self.rng.random() < self.feat_mask_apply_prob:
+            # apply feature masking
+            num_mask = int(num_nodes * self.feat_mask_prob)
+            mask_indices = self.rng.choice(num_nodes, num_mask)
+            aug_feat[mask_indices] = 0.0
+        if self.rng.random() < self.edge_perturb_apply_prob:
+            # apply feature masking
+            num_perturb = int(num_nodes * num_nodes * self.edge_perturb_prob)
+            num_perturb = num_perturb // 2  # perturb half and apply symmetry
+            x_indices = self.rng.choice(num_nodes, num_perturb, replace=True)  # allow duplicates
+            y_indices = self.rng.choice(num_nodes, num_perturb, replace=True)  # allow duplicates
+            perturbed_values = self.rng.random(num_perturb)
+            aug_adj[x_indices, y_indices] = perturbed_values
+            aug_adj[y_indices, x_indices] = perturbed_values
+            np.fill_diagonal(aug_adj, 0)  # restore perturbed diagonals
+        return orig_feat, orig_adj, aug_feat, aug_adj, orig_score
+
+
 def partition(list_feature, list_adj, list_NIH_score, args):
     num_total = len(list_feature)
     num_train = int(num_total * (1 - args.test_size - args.val_size))


### PR DESCRIPTION
안녕하세요. 저와 동재님이 작업한 Augmented Dataset 입니다.

아래 사진과 같이 사용하면 예전 batch 의 3가지 정보 (original node feat, original edge adj, label) 에 더해서 augmented node feat, augmented edge adj 도 나오게 됩니다.

랜덤하게 선택한 node 의 feature 들을 확률적으로 0 으로 만들거나 (0번째 2번째 아웃풋 비교)

랜덤하게 선택한 edge 들의 값을 확률적으로 0~1사이 값으로 바꿔줍니다 (1번째 3번째 아웃풋 비교) (사진에선 차이가 잘 안 보임)

아래 사진에서는 차이를 극대화하기 위해 일부러 augmentation 확률들을 높여서 적용했는데 실제로는 잘 조절해서 쓰면 될 것 같습니다.

더 자세한 옵션들은 코드 주석 참고해주세요.

감사합니다.

![image](https://user-images.githubusercontent.com/8216334/169291917-c1220f96-1de4-4a44-b332-9452ab67dd55.png)
