### PR TITLE
add 2 more aug types

### DIFF
--- a/GCN/multiclass_classification_GCN_acc_minmaxscaler_for_feature.py
+++ b/GCN/multiclass_classification_GCN_acc_minmaxscaler_for_feature.py
@@ -165,7 +165,7 @@ class GCNAugmentedDataset(Dataset):
             num_mask = int(num_nodes * self.feat_mask_prob)
             mask_indices = self.rng.choice(num_nodes, num_mask, replace=False)
             if len(mask_indices) > 0:
-                aug_feat[mask_indices] = self.rng.random(num_mask, feature_dim)  # 이젠 0 대신 noise로 mask
+                aug_feat[mask_indices] = self.rng.random((num_mask, feature_dim))  # 이젠 0 대신 noise로 mask
         if self.rng.random() < self.edge_perturb_apply_prob:
             # apply feature masking
             num_perturb = int(num_nodes * (num_nodes-1) * self.edge_perturb_prob * 0.5)

--- a/GCN/multiclass_classification_GCN_acc_minmaxscaler_for_feature.py
+++ b/GCN/multiclass_classification_GCN_acc_minmaxscaler_for_feature.py
@@ -191,7 +191,7 @@ class GCNAugmentedDataset(Dataset):
         for neighbor in self.neighbors(node):
             if neighbor in visited:
                 continue
-            self.get_all_connected_nodes(neighbor)
+            self._get_all_connected_nodes(neighbor)
 
 
 def partition(list_feature, list_adj, list_NIH_score, args):

--- a/GCN/multiclass_classification_GCN_acc_minmaxscaler_for_feature.py
+++ b/GCN/multiclass_classification_GCN_acc_minmaxscaler_for_feature.py
@@ -139,6 +139,7 @@ class GCNAugmentedDataset(Dataset):
         aug_feat = np.copy(orig_feat)
         aug_adj = np.copy(orig_adj)
         num_nodes = orig_feat.shape[0]
+        feature_dim = orig_feat.shape[1]
 
         if self.rng.random() < self.subgraph_apply_prob:
             num_subgraph_nodes = int(num_nodes * (1 - self.subgraph_prob))
@@ -164,7 +165,7 @@ class GCNAugmentedDataset(Dataset):
             num_mask = int(num_nodes * self.feat_mask_prob)
             mask_indices = self.rng.choice(num_nodes, num_mask, replace=False)
             if len(mask_indices) > 0:
-                aug_feat[mask_indices] = self.rng.random(num_mask)  # 이젠 0 대신 noise로 mask
+                aug_feat[mask_indices] = self.rng.random(num_mask, feature_dim)  # 이젠 0 대신 noise로 mask
         if self.rng.random() < self.edge_perturb_apply_prob:
             # apply feature masking
             num_perturb = int(num_nodes * (num_nodes-1) * self.edge_perturb_prob * 0.5)


### PR DESCRIPTION
node dropping 과 subgraph aug 방법을 더했습니다.

아까 얘기 나눈대로 attribute masking 은 이제 0 대신 noise로 마스킹합니다.

또한 디테일들을 조금 수정하였습니다.

아래는 노드 4개짜리 작은 예제로 테스트한 결과입니다.

## attribute masking 적용확률 100% 마스킹 50% (나머지 적용확률 0%)

![image](https://user-images.githubusercontent.com/8216334/170863930-dffea28d-86fc-43b4-ad18-88141b2f8a79.png)

노드 절반의 attribute이 noise로 변했습니다.

## edge perturbation 적용확률 100% perturb 50% (나머지 적용확률 0%)

![image](https://user-images.githubusercontent.com/8216334/170864262-3fb8c6fc-7da6-4467-9709-48cfaecfddf7.png)



edge의 절반이 perturb 되었고 symmetry 도 유지됩니다.

## node dropping 적용확률 100% 마스킹 50% (나머지 적용확률 0%)

![image](https://user-images.githubusercontent.com/8216334/170863975-9765cc3c-e543-400d-ba4b-4dd5ebf74043.png)

노드 절반의 attribute이 0으로 변했습니다

## subgraph 적용확률 100% 마스킹 50% (나머지 적용확률 0%)

![image](https://user-images.githubusercontent.com/8216334/170864140-f32b79b2-fe1c-4cc1-9ed0-701959e5a136.png)

마찬가지로 노드 절반의 attrribute이 0으로 변했습니다. 하지만 이 aug는 남아있는 node들의 연결관계를 보장합니다. 물론 샘플링할때 발견한 연결된 노드의 수가 필요한 subgraph 크기보다 작을땐, 크기를 맞추기 위해 여러번 샘플링을 수행하기 때문에 각자는 연결되어 있지만 서로는 연결되어 있지 않은 component 들로 구성될 가능성도 있습니다.



위의 테스트 결과는 각 aug 들을 따로따로 실험한 것이고, 확률을 주면 여러번 중첩되게 할 수도 있습니다.

서로의 관계는 딱히 고려하지 않았습니다. 예를 들어 subgraph 후에 node dropping 을 수행할 때, 앞서 구한 subgraph 내에서 확률적으로 node dropping 을 수행해야 의미론적으론 맞겠지만, 지금은 그냥 global 하게 node dropping 을 수행합니다. 수정 필요하면 의견 주시길 바랍니다.

감사합니다.